### PR TITLE
Fix RenameDetector to support exact and inexact matches for the same …

### DIFF
--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/diff/RenameDetectorTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/diff/RenameDetectorTest.java
@@ -184,6 +184,75 @@ public class RenameDetectorTest extends AbstractRenameDetectionTestCase {
 	}
 
 	@Test
+	public void testExactRenameAndInexactRename_OneDeleteOneExactOneInexactAdds() throws Exception {
+		ObjectId aId = blob("foo\nbar\nbaz\nblarg\n");
+		ObjectId bId = blob("foo\nbar\nbaz\nblah\n");
+
+		DiffEntry a = DiffEntry.add("src/com/foo/a.java", aId);
+		DiffEntry b = DiffEntry.add("src/com/foo/b.java", bId);
+
+		DiffEntry c = DiffEntry.delete("d.txt", aId);
+
+		rd.add(a);
+		rd.add(b);
+		rd.add(c);
+
+		List<DiffEntry> entries = rd.compute();
+		assertEquals(2, entries.size());
+
+		assertRename(c, a, 100, entries.get(0));
+		assertCopy(c, b, 65, entries.get(1));
+	}
+
+	@Test
+	public void testExactRenameAndInexactRename_OneDeleteTwoExactOneInexactAdds() throws Exception {
+		ObjectId aId = blob("foo\nbar\nbaz\nblarg\n");
+		ObjectId bId = blob("foo\nbar\nbaz\nblah\n");
+
+		DiffEntry a = DiffEntry.add("src/com/foo/a.java", aId);
+		DiffEntry b = DiffEntry.add("src/com/foo/b.java", aId);
+		DiffEntry c = DiffEntry.add("src/com/foo/c.java", bId);
+
+		DiffEntry d = DiffEntry.delete("d.txt", aId);
+
+		rd.add(a);
+		rd.add(b);
+		rd.add(c);
+		rd.add(d);
+
+		List<DiffEntry> entries = rd.compute();
+		assertEquals(3, entries.size());
+
+		assertRename(d, a, 100, entries.get(0));
+		assertCopy(d, b, 100, entries.get(1));
+		assertCopy(d, c, 65, entries.get(2));
+	}
+
+	@Test
+	public void testExactRenameAndInexactRename_OneDeleteOneExactTwoInexactAdds() throws Exception {
+		ObjectId aId = blob("foo\nbar\nbaz\nblarg\n");
+		ObjectId bId = blob("foo\nbar\nbaz\nblah\n");
+
+		DiffEntry a = DiffEntry.add("src/com/foo/a.java", aId);
+		DiffEntry b = DiffEntry.add("src/com/foo/b.java", bId);
+		DiffEntry c = DiffEntry.add("src/com/foo/c.java", bId);
+
+		DiffEntry d = DiffEntry.delete("d.txt", aId);
+
+		rd.add(a);
+		rd.add(b);
+		rd.add(c);
+		rd.add(d);
+
+		List<DiffEntry> entries = rd.compute();
+		assertEquals(3, entries.size());
+
+		assertRename(d, a, 100, entries.get(0));
+		assertCopy(d, b, 65, entries.get(1));
+		assertCopy(d, c, 65, entries.get(2));
+	}
+
+	@Test
 	public void testExactRename_UnstagedFile() throws Exception {
 		ObjectId aId = blob("foo");
 		DiffEntry a = DiffEntry.delete(PATH_A, aId);


### PR DESCRIPTION
…deleted file

RenameDetected supports matching a deleted file with multiple added files as long as all the matches are exact, or all the matches are inexact. The first match will be classified as a rename and the remaining will be classified as a copy.

If a deleted file A has the same content as a added file B and is similar to file C, RenameDetector will detect the rename A->B but will fail to detect the copy A->C. This commit fixes that.